### PR TITLE
Fix TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,6 @@ import { History } from 'history';
 
 type Stringify = (query: any) => string;
 type Parse = (query: string) => any;
-const historyWithQuery: (history: History, stringify: Stringify, parse: Parse) => History;
+declare const historyWithQuery: (history: History, stringify: Stringify, parse: Parse) => History;
 
 export default historyWithQuery;


### PR DESCRIPTION
TS is currently failing with this error:

> node_modules/qhistory/index.d.ts:5:1 - error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.

`type` (and `interface`) doesn't need `declare` modifier, but `const`, `function` etc do.