### PR TITLE
Support history v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "cross-env": "^3.1.4",
-    "history": "^4.5.1",
+    "history": "^5.0.0",
     "jest": "^18.1.0",
     "qs": "^6.3.0",
     "rimraf": "^2.5.4",

--- a/src/index.js
+++ b/src/index.js
@@ -57,14 +57,8 @@ const qhistory = (history, stringify, parse) => {
     updateProperties(history)
   })
 
-  // make sure that the initial location has query support
-  addQuery(history.location)
-
   const queryHistory = {
     ...history,
-    get location() {
-      return addQuery(history.location)
-    },
     listen: (listener) =>
       history.listen((location, action) => {
         const isV5 = location.location != null
@@ -82,6 +76,10 @@ const qhistory = (history, stringify, parse) => {
     createHref: (location) =>
       history.createHref(addSearch(location))
   }
+
+  Object.defineProperty(queryHistory, 'location', {
+    get: () => addQuery(history.location),
+  })
 
   return queryHistory
 }

--- a/tests/qhistory.spec.js
+++ b/tests/qhistory.spec.js
@@ -34,7 +34,9 @@ describe('qhistory', () => {
 
       q.listen(({location}) => {
         expect(location.query).toEqual({ tooGoodToBe: 'true' })
+        expect(q.location.query).toEqual({ tooGoodToBe: 'true' })
         expect(location.search).toBe('?tooGoodToBe=true')
+        expect(q.location.search).toBe('?tooGoodToBe=true')
       })
 
       q.push('/test?tooGoodToBe=true')

--- a/tests/qhistory.spec.js
+++ b/tests/qhistory.spec.js
@@ -32,7 +32,7 @@ describe('qhistory', () => {
       const history = createMemoryHistory()
       const q = qhistory(history, stringify, parse)
 
-      q.listen((location) => {
+      q.listen(({location}) => {
         expect(location.query).toEqual({ tooGoodToBe: 'true' })
         expect(location.search).toBe('?tooGoodToBe=true')
       })
@@ -44,7 +44,7 @@ describe('qhistory', () => {
       const history = createMemoryHistory()
       const q = qhistory(history, stringify, parse)
 
-      q.listen((location) => {
+      q.listen(({location}) => {
         expect(location.query).toBeInstanceOf(Object)
         expect(Object.keys(location.query).length).toBe(0)
       })
@@ -56,41 +56,41 @@ describe('qhistory', () => {
   describe('search', () => {
     it('will prefer query object over search string', () => {
       const history = createMemoryHistory()
+      history.push = jest.fn();
       const q = qhistory(history, stringify, parse)
 
       q.push({ pathname: '/somewhere',
         search: '?overRainbow=false',
         query: { overRainbow: true }
       })
-      const mostRecentLocation = q.entries[q.entries.length-1]
-      expect(mostRecentLocation.search).toBe('?overRainbow=true')
+      expect(history.push).toHaveBeenCalledWith(expect.objectContaining({search: '?overRainbow=true'}), undefined)
     })
 
     it('uses search if no query provided', () => {
       const history = createMemoryHistory()
+      history.push = jest.fn();
       const q = qhistory(history, stringify, parse)
       q.push({ pathname: '/somewhere', search: '?overRainbow=false' })
-      const mostRecentLocation = q.entries[q.entries.length-1]
-      expect(mostRecentLocation.search).toBe('?overRainbow=false')
+      expect(history.push).toHaveBeenCalledWith(expect.objectContaining({search: '?overRainbow=false'}), undefined)
     })
 
     it('sets search to empty string if no query/search', () => {
       const history = createMemoryHistory()
+      history.push = jest.fn();
       const q = qhistory(history, stringify, parse)
       q.push({ pathname: '/somewhere' })
-      const mostRecentLocation = q.entries[q.entries.length-1]
-      expect(mostRecentLocation.search).toBe('')
+      expect(history.push).toHaveBeenCalledWith(expect.objectContaining({search: ''}), undefined)
     })
   })
 
   describe('push', () => {
     it('will set search string for location passed to actual history', () => {
       const history = createMemoryHistory()
+      history.push = jest.fn();
       const q = qhistory(history, stringify, parse)
 
       q.push({ pathname: '/somewhere', query: { overRainbow: true }})
-      const mostRecentLocation = q.entries[q.entries.length-1]
-      expect(mostRecentLocation.search).toBe('?overRainbow=true')
+      expect(history.push).toHaveBeenCalledWith(expect.objectContaining({search: '?overRainbow=true'}), undefined)
     })
 
     it('will call the history instance\'s push method', () => {
@@ -105,23 +105,20 @@ describe('qhistory', () => {
   describe('replace', () => {
     it('will set search string for location passed to actual history', () => {
       const history = createMemoryHistory()
+      history.replace = jest.fn();
       const q = qhistory(history, stringify, parse)
 
-      expect(q.length).toBe(1)
       q.replace({ pathname: '/somewhere', query: { overRainbow: true }})
-      const mostRecentLocation = q.entries[q.entries.length-1]
-      expect(mostRecentLocation.search).toBe('?overRainbow=true')
+      expect(history.replace).toHaveBeenCalledWith(expect.objectContaining({search: '?overRainbow=true'}), undefined)
     })
 
     it('will call the history instance\'s replace method', () => {
       const history = createMemoryHistory()
+      history.replace = jest.fn();
       const q = qhistory(history, stringify, parse)
 
-      expect(q.length).toBe(1)
       q.replace({ pathname: '/somewhere', query: { overRainbow: true }})
-      // test length to ensure replace was called
-      expect(q.length).toBe(1)
-      expect(q.action).toBe('REPLACE')
+      expect(history.replace).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
There are some major API changes in `history@5`, which are addressed in this PR, see https://github.com/ReactTraining/history/issues/811

How to test compatibility with v4:
- revert changes in `package.json` & `tests/qhistory.spec.js`
- run `npm install && npm test`